### PR TITLE
Fix for paths being incorrectly generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fork of https://github.com/PiggyPot/onfido updated for v3.
 ```elixir
 def deps do
   [
-    {:onfido_v3, github: "piratestudios/onfido_v3", tag: "0.1.0"}
+    {:onfido_v3, github: "piratestudios/onfido_v3", tag: "0.1.1"}
   ]
 end
 ```

--- a/lib/comms/http_driver.ex
+++ b/lib/comms/http_driver.ex
@@ -10,8 +10,9 @@ defmodule Onfido.Comms.HttpDriver do
 
   def request(:get, path, params) do
     url_params = params |> URI.encode_query()
+    string = if url_params == "", do: "#{path}", else: "#{path}?#{url_params}"
 
-    "#{path}?#{url_params}"
+    string
     |> api_url()
     |> HTTPoison.get(headers(), options())
     |> decode_json()


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1pF9ZTbLtSSm3IBvbW7jzd0AqDhhArA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=XNuupdS)

Fix for generated paths incorrectly having a `?` added with no query string params