### PR TITLE
Bugfix | Updating HTTPoison and elixir version

### DIFF
--- a/lib/comms/http_driver.ex
+++ b/lib/comms/http_driver.ex
@@ -46,12 +46,18 @@ defmodule Onfido.Comms.HttpDriver do
     ]
   end
 
-  defp options do
-    [ssl: [
-      {:versions, [:"tlsv1.2"]},
-      {:customize_hostname_check, [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]}
-    ]]
-  end
+    defp default_ssl_options() do
+      [
+        {:versions, [:"tlsv1.2", :"tlsv1.3"]},
+        {:verify, :verify_peer},
+        {:cacertfile, :certifi.cacertfile()},
+        {:depth, 10},
+        {:customize_hostname_check,
+         [
+           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+         ]}
+      ]
+    end
 
   defp decode_json({:ok, resp_map}) do
     case resp_map.body do

--- a/lib/comms/http_driver.ex
+++ b/lib/comms/http_driver.ex
@@ -47,7 +47,10 @@ defmodule Onfido.Comms.HttpDriver do
   end
 
   defp options do
-    [ssl: [{:versions, [:"tlsv1.2"]}]]
+    [ssl: [
+      {:versions, [:"tlsv1.2"]},
+      {:customize_hostname_check, [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]}
+    ]]
   end
 
   defp decode_json({:ok, resp_map}) do

--- a/lib/comms/http_driver.ex
+++ b/lib/comms/http_driver.ex
@@ -2,7 +2,7 @@ defmodule Onfido.Comms.HttpDriver do
   def request(:delete, path) do
     path
     |> api_url()
-    |> HTTPoison.delete(headers(), options())
+    |> HTTPoison.delete(headers(), default_ssl_options())
     |> decode_json()
   end
 
@@ -14,7 +14,7 @@ defmodule Onfido.Comms.HttpDriver do
 
     string
     |> api_url()
-    |> HTTPoison.get(headers(), options())
+    |> HTTPoison.get(headers(), default_ssl_options())
     |> decode_json()
   end
 
@@ -23,7 +23,7 @@ defmodule Onfido.Comms.HttpDriver do
 
     path
     |> api_url()
-    |> HTTPoison.post(payload, headers(), options())
+    |> HTTPoison.post(payload, headers(), default_ssl_options())
     |> decode_json()
   end
 
@@ -32,7 +32,7 @@ defmodule Onfido.Comms.HttpDriver do
 
     path
     |> api_url()
-    |> HTTPoison.put(payload, headers(), options())
+    |> HTTPoison.put(payload, headers(), default_ssl_options())
     |> decode_json()
   end
 
@@ -46,18 +46,18 @@ defmodule Onfido.Comms.HttpDriver do
     ]
   end
 
-    defp default_ssl_options() do
-      [
-        {:versions, [:"tlsv1.2", :"tlsv1.3"]},
-        {:verify, :verify_peer},
-        {:cacertfile, :certifi.cacertfile()},
-        {:depth, 10},
-        {:customize_hostname_check,
-         [
-           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-         ]}
-      ]
-    end
+  defp default_ssl_options() do
+    [
+      {:versions, [:"tlsv1.2", :"tlsv1.3"]},
+      {:verify, :verify_peer},
+      {:cacertfile, :certifi.cacertfile()},
+      {:depth, 10},
+      {:customize_hostname_check,
+        [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]}
+    ]
+  end
 
   defp decode_json({:ok, resp_map}) do
     case resp_map.body do

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Onfido.MixProject do
       app: :onfido_v3,
       description: "Elixir wrapper for v3 of the Onfido API",
       package: package(),
-      version: "0.1.3",
-      elixir: "~> 1.7",
+      version: "0.1.4",
+      elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Onfido.MixProject do
     [
       {:ex_doc, "~> 0.19.0", only: :dev, runtime: false},
       {:httpoison_form_data, "~> 0.1"},
-      {:httpoison, "~> 1.6"},
+      {:httpoison, "~> 2.0"},
       {:poison, "~> 3.1"}
     ]
   end


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX17ERnWctJLmKo2hJwfp6RPPuXeBtLbMg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=n8oOdUL)

Updating HTTPoison and elixir version

Can test out locally by changing your mix.exs to reference `{:onfido_v3, github: "piratestudios/onfido_v3", branch: "bugfix/mark2"}`